### PR TITLE
Fix comment toggling for // and # line comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ VS Code extension for [SurrealQL](https://surrealdb.com), the query language for
 
 - **Syntax highlighting** via a TextMate grammar (also injected into Markdown code fences and JS/TS template literals).
 - **Snippets** for common SurrealQL constructs.
+- **Comment toggling** — `Ctrl+/` / `Cmd+/` understands all three SurrealQL line-comment markers (`--`, `//`, `#`), uncommenting whichever style a line uses.
 - **Language server** (`surrealql-language-server`) for diagnostics, completion, hover, go-to-definition, and references. The binary is downloaded from GitHub releases on first activation and cached under VS Code's global storage.
 - **Run Query** — a `▶ Run` code lens above every top-level statement in `.surql` / `.surrealql` files. Clicking it executes that statement against the configured SurrealDB endpoint.
 - **SurrealQL Results** panel — bottom-panel view that displays a history of executed queries (max 50) with a table or JSON detail view.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"lint:check": "biome check . --formatter-enabled=false",
 		"lint:apply": "biome check . --formatter-enabled=false --write",
 		"lint:apply:unsafe": "biome check . --formatter-enabled=false --write --unsafe",
-		"test": "bun test test/textmate",
+		"test": "bun test test/textmate test/comments",
+		"test:comments": "bun test test/comments",
 		"test:textmate": "bun test test/textmate",
 		"validate": "bun run build:grammar && bun run typecheck && biome check . && bun run test && bun run build"
 	},
@@ -122,8 +123,29 @@
 				"command": "surrealql.clearResults",
 				"title": "SurrealQL: Clear Query Results",
 				"category": "SurrealQL"
+			},
+			{
+				"command": "surrealql.toggleLineComment",
+				"title": "SurrealQL: Toggle Line Comment",
+				"category": "SurrealQL"
 			}
 		],
+		"keybindings": [
+			{
+				"command": "surrealql.toggleLineComment",
+				"key": "ctrl+/",
+				"mac": "cmd+/",
+				"when": "editorTextFocus && !editorReadonly && editorLangId == surrealql"
+			}
+		],
+		"menus": {
+			"commandPalette": [
+				{
+					"command": "surrealql.toggleLineComment",
+					"when": "editorLangId == surrealql"
+				}
+			]
+		},
 		"viewsContainers": {
 			"panel": [
 				{

--- a/src/comments/toggleLineComment.ts
+++ b/src/comments/toggleLineComment.ts
@@ -1,0 +1,130 @@
+/**
+ * Multi-token line-comment toggling for SurrealQL.
+ *
+ * SurrealQL accepts three line-comment markers (`--`, `//` and `#`), but a VS
+ * Code language configuration can declare only a single `lineComment` token,
+ * so the built-in "Toggle Line Comment" action recognises `--` alone and
+ * stacks a second marker on top of `//` or `#` comments instead of removing
+ * them. The `surrealql.toggleLineComment` command (bound to the same keys as
+ * the built-in action in `package.json`) uncomments any of the three markers
+ * and comments with the canonical `--`.
+ *
+ * This module is deliberately free of `vscode` imports so the edit
+ * computation can be unit-tested outside the extension host; the thin editor
+ * wiring lives in `extension.ts`.
+ */
+
+export const TOGGLE_LINE_COMMENT_COMMAND = "surrealql.toggleLineComment";
+
+/** Line-comment markers SurrealQL accepts. */
+export const LINE_COMMENT_TOKENS = ["--", "//", "#"] as const;
+
+/** Marker inserted when commenting, matching `language-configuration.json`. */
+export const DEFAULT_LINE_COMMENT = "--";
+
+/** A run of consecutive lines covered by one selection, 0-based inclusive. */
+export interface LineRange {
+	startLine: number;
+	endLine: number;
+}
+
+export type ToggleEdit =
+	| { kind: "insert"; line: number; character: number; text: string }
+	| { kind: "delete"; line: number; startCharacter: number; endCharacter: number };
+
+/**
+ * Lines a selection toggles. A multi-line selection whose end sits at column
+ * 0 excludes that final line, matching the built-in action.
+ */
+export function selectionLineRange(
+	startLine: number,
+	endLine: number,
+	endCharacter: number,
+): LineRange {
+	if (endLine > startLine && endCharacter === 0) {
+		return { startLine, endLine: endLine - 1 };
+	}
+	return { startLine, endLine };
+}
+
+interface AnalyzedLine {
+	line: number;
+	text: string;
+	/** Offset of the first non-whitespace character, or -1 for blank lines. */
+	indent: number;
+	/** The comment marker the line starts with, if any. */
+	token: string | undefined;
+}
+
+function analyzeLine(line: number, text: string): AnalyzedLine {
+	const indent = text.search(/\S/);
+	const token =
+		indent === -1
+			? undefined
+			: LINE_COMMENT_TOKENS.find((candidate) => text.startsWith(candidate, indent));
+	return { line, text, indent, token };
+}
+
+/**
+ * Compute the edits that toggle line comments across the given ranges.
+ *
+ * Mirrors the built-in "Toggle Line Comment" semantics, per range: when every
+ * non-blank line already starts with one of the SurrealQL markers the markers
+ * are removed (each line keeps its own style), otherwise every non-blank line
+ * gains a `--` marker aligned at the block's minimum indentation — including
+ * already-commented lines, so toggling twice restores the original text.
+ * Blank lines are skipped unless the range contains nothing else, in which
+ * case they are commented so a lone cursor on an empty line still produces a
+ * marker. Lines claimed by an earlier range are skipped so overlapping
+ * multi-cursor selections never produce conflicting edits.
+ */
+export function computeToggleEdits(
+	getLineText: (line: number) => string,
+	ranges: readonly LineRange[],
+	insertSpace = true,
+): ToggleEdit[] {
+	const edits: ToggleEdit[] = [];
+	const marker = insertSpace ? `${DEFAULT_LINE_COMMENT} ` : DEFAULT_LINE_COMMENT;
+	const claimed = new Set<number>();
+
+	for (const range of ranges) {
+		const lines: AnalyzedLine[] = [];
+		for (let line = range.startLine; line <= range.endLine; line++) {
+			if (claimed.has(line)) continue;
+			claimed.add(line);
+			lines.push(analyzeLine(line, getLineText(line)));
+		}
+
+		const content = lines.filter((entry) => entry.indent !== -1);
+		if (content.length === 0) {
+			for (const entry of lines) {
+				edits.push({
+					kind: "insert",
+					line: entry.line,
+					character: entry.text.length,
+					text: marker,
+				});
+			}
+			continue;
+		}
+
+		if (content.every((entry) => entry.token !== undefined)) {
+			for (const entry of content) {
+				if (entry.token === undefined) continue;
+				const startCharacter = entry.indent;
+				let endCharacter = startCharacter + entry.token.length;
+				if (insertSpace && entry.text.charAt(endCharacter) === " ") {
+					endCharacter += 1;
+				}
+				edits.push({ kind: "delete", line: entry.line, startCharacter, endCharacter });
+			}
+		} else {
+			const character = Math.min(...content.map((entry) => entry.indent));
+			for (const entry of content) {
+				edits.push({ kind: "insert", line: entry.line, character, text: marker });
+			}
+		}
+	}
+
+	return edits;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,9 @@
 import * as vscode from "vscode";
+import {
+	computeToggleEdits,
+	selectionLineRange,
+	TOGGLE_LINE_COMMENT_COMMAND,
+} from "./comments/toggleLineComment";
 import { SurQLLanguageClient } from "./lsp/client";
 import { LanguageServerDownloader } from "./lsp/downloader";
 import {
@@ -18,6 +23,7 @@ import { OPEN_SETTINGS_COMMAND, SurQLStatusBarItem } from "./statusbar/statusBar
  *  - the "▶ Run" code lens above each top-level statement,
  *  - the SurrealQL Results webview panel,
  *  - the SurrealQL connection status bar widget,
+ *  - the multi-token line-comment toggle bound to the standard toggle keys,
  *  - the commands they trigger.
  */
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -68,6 +74,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			}
 		}),
 		vscode.commands.registerCommand("surrealql.clearResults", () => resultsProvider.clear()),
+		vscode.commands.registerTextEditorCommand(TOGGLE_LINE_COMMENT_COMMAND, toggleLineComment),
 		vscode.workspace.onDidChangeConfiguration(async (e) => {
 			if (!e.affectsConfiguration("surrealql")) return;
 			if (affectsStatusBar(e)) statusBar.refresh();
@@ -104,6 +111,40 @@ async function ensureStorageRoot(context: vscode.ExtensionContext): Promise<void
 		await vscode.workspace.fs.createDirectory(context.globalStorageUri);
 	} catch {
 		/* directory may already exist */
+	}
+}
+
+/**
+ * Toggle line comments across all selections. Replaces the built-in
+ * `editor.action.commentLine` for SurrealQL files (rebound to the same keys
+ * in `package.json`) because a language configuration can declare only one
+ * line-comment token while SurrealQL accepts `--`, `//` and `#`.
+ */
+function toggleLineComment(editor: vscode.TextEditor, edit: vscode.TextEditorEdit): void {
+	const insertSpace = vscode.workspace
+		.getConfiguration("editor", editor.document)
+		.get("comments.insertSpace", true);
+	const ranges = editor.selections.map((selection) =>
+		selectionLineRange(selection.start.line, selection.end.line, selection.end.character),
+	);
+	const edits = computeToggleEdits(
+		(line) => editor.document.lineAt(line).text,
+		ranges,
+		insertSpace,
+	);
+	for (const change of edits) {
+		if (change.kind === "insert") {
+			edit.insert(new vscode.Position(change.line, change.character), change.text);
+		} else {
+			edit.delete(
+				new vscode.Range(
+					change.line,
+					change.startCharacter,
+					change.line,
+					change.endCharacter,
+				),
+			);
+		}
 	}
 }
 

--- a/test/comments/toggleLineComment.test.ts
+++ b/test/comments/toggleLineComment.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import {
+	computeToggleEdits,
+	type LineRange,
+	selectionLineRange,
+	type ToggleEdit,
+} from "../../src/comments/toggleLineComment";
+
+/** Apply computed edits to a document held as an array of lines. */
+function apply(lines: readonly string[], edits: readonly ToggleEdit[]): string[] {
+	const result = [...lines];
+	for (const edit of edits) {
+		const text = result[edit.line];
+		result[edit.line] =
+			edit.kind === "insert"
+				? text.slice(0, edit.character) + edit.text + text.slice(edit.character)
+				: text.slice(0, edit.startCharacter) + text.slice(edit.endCharacter);
+	}
+	return result;
+}
+
+function toggle(lines: readonly string[], ranges?: readonly LineRange[], insertSpace = true) {
+	const covered = ranges ?? [{ startLine: 0, endLine: lines.length - 1 }];
+	return apply(
+		lines,
+		computeToggleEdits((line) => lines[line], covered, insertSpace),
+	);
+}
+
+describe("computeToggleEdits", () => {
+	test("comments an uncommented line with --", () => {
+		expect(toggle(["SELECT * FROM person;"])).toEqual(["-- SELECT * FROM person;"]);
+	});
+
+	test("uncomments each SurrealQL marker", () => {
+		expect(toggle(["-- SELECT 1;"])).toEqual(["SELECT 1;"]);
+		expect(toggle(["// SELECT 1;"])).toEqual(["SELECT 1;"]);
+		expect(toggle(["# SELECT 1;"])).toEqual(["SELECT 1;"]);
+	});
+
+	test("uncomments markers not followed by a space", () => {
+		expect(toggle(["--SELECT 1;"])).toEqual(["SELECT 1;"]);
+		expect(toggle(["//SELECT 1;"])).toEqual(["SELECT 1;"]);
+		expect(toggle(["#SELECT 1;"])).toEqual(["SELECT 1;"]);
+	});
+
+	test("removes only one marker per toggle", () => {
+		expect(toggle(["-- -- SELECT 1;"])).toEqual(["-- SELECT 1;"]);
+		expect(toggle(["-- # SELECT 1;"])).toEqual(["# SELECT 1;"]);
+	});
+
+	test("uncomments a block of mixed marker styles", () => {
+		expect(toggle(["-- a", "// b", "# c"])).toEqual(["a", "b", "c"]);
+	});
+
+	test("comments a partially commented block and round-trips", () => {
+		const mixed = ["# a", "b"];
+		const commented = toggle(mixed);
+		expect(commented).toEqual(["-- # a", "-- b"]);
+		expect(toggle(commented)).toEqual(mixed);
+	});
+
+	test("preserves leading whitespace when uncommenting", () => {
+		expect(toggle(["    -- a"])).toEqual(["    a"]);
+		expect(toggle(["\t# a"])).toEqual(["\ta"]);
+	});
+
+	test("aligns markers at the block's minimum indentation", () => {
+		expect(toggle(["    a", "        b"])).toEqual(["    -- a", "    --     b"]);
+	});
+
+	test("skips blank lines when commenting a block", () => {
+		expect(toggle(["a", "", "b"])).toEqual(["-- a", "", "-- b"]);
+	});
+
+	test("ignores blank lines when deciding to uncomment", () => {
+		expect(toggle(["-- a", "", "-- b"])).toEqual(["a", "", "b"]);
+	});
+
+	test("comments blank lines when the range holds nothing else", () => {
+		expect(toggle([""])).toEqual(["-- "]);
+		expect(toggle(["    "])).toEqual(["    -- "]);
+	});
+
+	test("honours insertSpace = false", () => {
+		expect(toggle(["a"], undefined, false)).toEqual(["--a"]);
+		expect(toggle(["-- a"], undefined, false)).toEqual([" a"]);
+	});
+
+	test("decides comment vs uncomment per range", () => {
+		const lines = ["-- a", "b"];
+		const ranges = [
+			{ startLine: 0, endLine: 0 },
+			{ startLine: 1, endLine: 1 },
+		];
+		expect(toggle(lines, ranges)).toEqual(["a", "-- b"]);
+	});
+
+	test("edits a line claimed by several ranges only once", () => {
+		const ranges = [
+			{ startLine: 0, endLine: 0 },
+			{ startLine: 0, endLine: 0 },
+		];
+		expect(toggle(["a"], ranges)).toEqual(["-- a"]);
+	});
+});
+
+describe("selectionLineRange", () => {
+	test("keeps single-line selections", () => {
+		expect(selectionLineRange(3, 3, 0)).toEqual({ startLine: 3, endLine: 3 });
+	});
+
+	test("drops the final line when a multi-line selection ends at column 0", () => {
+		expect(selectionLineRange(0, 2, 0)).toEqual({ startLine: 0, endLine: 1 });
+	});
+
+	test("keeps the final line when the selection ends past column 0", () => {
+		expect(selectionLineRange(0, 2, 5)).toEqual({ startLine: 0, endLine: 2 });
+	});
+});


### PR DESCRIPTION
Fixes #27

## Problem

SurrealQL accepts three line-comment markers (`--`, `//`, `#`), but a VS Code language configuration can declare only a **single** `lineComment` token — ours is `--`. The built-in `Ctrl+/` toggle therefore never recognises `//` or `#` comments: instead of uncommenting them it stacks a `--` marker on top.

## Fix

Since the one-token limit is a VS Code platform constraint, the fix registers a `surrealql.toggleLineComment` command and rebinds `Ctrl+/` / `Cmd+/` to it for SurrealQL files only (`when: editorTextFocus && !editorReadonly && editorLangId == surrealql`). The command mirrors the built-in toggle semantics, extended to all three markers:

- **Uncommenting** removes whichever marker each line uses (`--`, `//`, or `#`), plus one following space, preserving indentation.
- **Commenting** inserts the canonical `--` aligned at the block's minimum indentation, skipping blank lines (unless the selection is only blank lines, so a lone cursor on an empty line still gets a marker).
- A block is "commented" only when **every** non-blank line carries a marker — mixed styles (`# a` / `// b` / `-- c`) uncomment in one keystroke; partially commented blocks gain a marker on every line so toggling twice round-trips to the original text.
- Per-selection toggle decisions, multi-cursor dedupe, the trailing-line-at-column-0 exclusion, and `editor.comments.insertSpace` all match the built-in behaviour.

The edit computation lives in a `vscode`-free module (`src/comments/toggleLineComment.ts`) so it's covered by plain bun tests (`test/comments/`, 17 cases); the extension wiring is a thin mapper in `extension.ts`. Block comments (`/* */`, `Shift+Alt+A`) are untouched and keep working via the existing language configuration, which stays as-is since the `lineComment` token still drives other editor features.

Invocations of the built-in **Toggle Line Comment** through the command palette or Edit menu (rather than the keybinding) keep the old `--`-only behaviour — there's no API to override the built-in per language — but the new command is exposed in the palette as **SurrealQL: Toggle Line Comment** for SurrealQL files.

## Validation

`bun run validate` passes: grammar build, typecheck, biome, all 34 tests (17 new), esbuild bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)