### PR TITLE
ci: open a bump pull request when the LSP announces a release

### DIFF
--- a/.github/workflows/bump-lsp.yml
+++ b/.github/workflows/bump-lsp.yml
@@ -1,0 +1,83 @@
+# Opens a pull request that bumps the pinned surrealql-language-server
+# version (.lsp-version) when the LSP repo announces a release.
+#
+# Triggered by the `lsp-release` repository_dispatch sent from
+# surrealql-language-server's notify-consumers workflow, which only fires
+# after all four release binaries are attached. The workflow_dispatch
+# trigger exists for backfills and recovery.
+#
+# The pull request is created with a GitHub App token, not GITHUB_TOKEN:
+# a pull request created by GITHUB_TOKEN does not start CI, so the bump
+# would sit unverified.
+name: Bump LSP version
+
+on:
+  repository_dispatch:
+    types: [lsp-release]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'LSP release tag (for example v0.5.2)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Resolve and validate the tag
+        id: tag
+        env:
+          DISPATCH_TAG: ${{ github.event.client_payload.tag }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          TAG="${INPUT_TAG:-$DISPATCH_TAG}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$TAG' must match vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Write the pin
+        id: pin
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          printf '%s\n' "$TAG" > .lsp-version
+          if git diff --quiet -- .lsp-version; then
+            echo "The pin is already $TAG. Nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mint an installation token
+        if: steps.pin.outputs.changed == 'true'
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.LSP_BUMP_APP_ID }}
+          private-key: ${{ secrets.LSP_BUMP_APP_PRIVATE_KEY }}
+
+      - name: Open the pull request
+        if: steps.pin.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app.outputs.token }}
+          branch: bump-lsp
+          base: main
+          commit-message: 'chore: bump surrealql-language-server to ${{ steps.tag.outputs.tag }}'
+          title: 'chore: bump surrealql-language-server to ${{ steps.tag.outputs.tag }}'
+          body: |
+            Bumps the pinned `surrealql-language-server` version to `${{ steps.tag.outputs.tag }}`.
+
+            Release notes: https://github.com/surrealdb/surrealql-language-server/releases/tag/${{ steps.tag.outputs.tag }}
+
+            Opened automatically by the `Bump LSP version` workflow. A repeat
+            announcement for the same tag updates this pull request instead of
+            opening a second one.


### PR DESCRIPTION
Part of the cross-repo bump automation for `surrealql-language-server` releases.

Adds the `Bump LSP version` workflow. It listens for the `lsp-release` `repository_dispatch` sent by the LSP repo's `notify-consumers` workflow — which fires only after **all four release binaries are attached** (the release-published event itself fires on an empty release; measured worst case 17m32s until the last asset) — and opens a pull request that updates `.lsp-version`. `workflow_dispatch` with a tag input covers backfills and recovery.

Design points a reviewer should check:

- **The PR is opened with a GitHub App token, not `GITHUB_TOKEN`** — a PR created by `GITHUB_TOKEN` does not trigger CI, so bumps would sit unverified. Needs the `LSP_BUMP_APP_ID` / `LSP_BUMP_APP_PRIVATE_KEY` secrets (App: `surrealql-lsp-bump`, to be created by an org owner — see the tracking notes in the LSP repo PR).
- **Fixed branch `bump-lsp`**: a repeat announcement updates the open PR instead of stacking a second one; an unchanged pin ends the run without a PR.
- Tag validated against `^v[0-9]+\.[0-9]+\.[0-9]+$` — prerelease tags never reach this workflow (the dispatcher skips prereleases), and malformed input fails loudly.

**Merge order:** merge surrealdb/surrealql-vsx#33 first — this workflow edits the pin that PR introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
